### PR TITLE
Add --lock option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For full installation documention see the [installation docs][docs/install.md].
 
 ## Usage
 
-`bwm [-h] [-v VAULT] [-l LOGIN] [-a AUTOTYPE]`
+`bwm [-h] [-v VAULT] [-l LOGIN] [-k] [-a AUTOTYPE]`
 
 - Run `bwm` or bind to keystroke combination.
 - Enter account URL on first run.

--- a/bwm.1
+++ b/bwm.1
@@ -9,19 +9,21 @@ bitwarden-menu - Fully featured Dmenu/Rofi/Bemenu frontend for autotype
 and managing of Bitwarden/Vaultwarden vaults.
 .SH SYNOPSIS
 .PP
-\f[B]bitwarden-menu\f[R] [\f[B]\[en]vault\f[R] URL]
-[\f[B]\[en]login\f[R] email] [\f[B]\[en]autotype\f[R] pattern]
+\f[B]bitwarden-menu\f[R] [\f[B]--vault\f[R] URL]
+[\f[B]--login\f[R] email] [\f[B]--lock\f[R]] [\f[B]\[en]autotype\f[R] pattern]
 .SH DESCRIPTION
 .PP
 \f[B]Bitwarden-menu\f[R] is a fast and minimal application to facilitate
 password entry and manage most aspects of Bitwarden/Vaultwarden vaults.
 .SH OPTIONS
 .PP
-\f[B]-v\f[R], \f[B]\[en]vault\f[R] Vault URL
+\f[B]-v\f[R], \f[B]--vault\f[R] Vault URL
 .PP
-\f[B]-l\f[R], \f[B]\[en]login\f[R] Login email address
+\f[B]-l\f[R], \f[B]--login\f[R] Login email address
 .PP
-\f[B]-a\f[R], \f[B]\[en]autotype\f[R] Autotype sequence from
+\f[B]-k\f[R], \f[B]--lock\f[R] Lock vault
+.PP
+\f[B]-a\f[R], \f[B]--autotype\f[R] Autotype sequence from
 https://keepass.info/help/base/autotype.html#autoseq .
 Overrides global default from config.ini for current vault.
 .SH EXAMPLES

--- a/bwm.1.md
+++ b/bwm.1.md
@@ -13,7 +13,7 @@ managing of Bitwarden/Vaultwarden vaults.
 
 # SYNOPSIS
 
-**bitwarden-menu** [**--vault** URL] [**--login** email] [**--autotype** pattern]
+**bitwarden-menu** [**--vault** URL] [**--login** email] [**--lock**] [**--autotype** pattern]
 
 # DESCRIPTION
 
@@ -25,6 +25,8 @@ manage most aspects of Bitwarden/Vaultwarden vaults.
 **-v**, **--vault** Vault URL
 
 **-l**, **--login**  Login email address
+
+**-k**, **--lock**  Lock vault
 
 **-a**, **--autotype**  Autotype sequence from
 https://keepass.info/help/base/autotype.html#autoseq . Overrides global default

--- a/bwm/__main__.py
+++ b/bwm/__main__.py
@@ -151,6 +151,14 @@ def main():
     )
 
     parser.add_argument(
+        "-k",
+        "--lock",
+        required=False,
+        action='store_true',
+        help="Lock vault",
+    )
+
+    parser.add_argument(
         "-l",
         "--login",
         type=str,

--- a/bwm/bwm.py
+++ b/bwm/bwm.py
@@ -403,7 +403,6 @@ class DmenuRunner(multiprocessing.Process):
 
     def run(self):
         at_saved = ""
-        lock = False
         while True:
             self.server.start_flag.wait()
             if self.server.kill_flag.is_set():
@@ -418,14 +417,11 @@ class DmenuRunner(multiprocessing.Process):
                 dargs = self.server.get_args()
                 self.server.args_flag.clear()
             self.vault.autotype = dargs.get('autotype', "") or bwm.SEQUENCE
-            if dargs.get('lock', False):
-                lock = True
             if dargs.get('vault', ""):
                 res = Run.SWITCH
                 at_saved = self.vault.autotype
-            elif lock:
+            elif dargs.get('lock', False):
                 bwcli.lock()
-                lock = False
                 res = Run.LOCK
             else:
                 self.vault.autotype = at_saved if at_saved else self.vault.autotype

--- a/bwm/bwm.py
+++ b/bwm/bwm.py
@@ -403,6 +403,7 @@ class DmenuRunner(multiprocessing.Process):
 
     def run(self):
         at_saved = ""
+        lock = False
         while True:
             self.server.start_flag.wait()
             if self.server.kill_flag.is_set():
@@ -417,9 +418,15 @@ class DmenuRunner(multiprocessing.Process):
                 dargs = self.server.get_args()
                 self.server.args_flag.clear()
             self.vault.autotype = dargs.get('autotype', "") or bwm.SEQUENCE
+            if dargs.get('lock', False):
+                lock = True
             if dargs.get('vault', ""):
                 res = Run.SWITCH
                 at_saved = self.vault.autotype
+            elif lock:
+                bwcli.lock()
+                lock = False
+                res = Run.LOCK
             else:
                 self.vault.autotype = at_saved if at_saved else self.vault.autotype
                 at_saved = ""

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,13 +13,15 @@
 
 ## CLI Options
 
-`bwm [-h] [-v VAULT] [-l LOGIN] [-a AUTOTYPE] `
+`bwm [-h] [-v VAULT] [-l LOGIN] [-k] [-a AUTOTYPE] `
 
 --help, -h Output a usage message and exit.
 
 -v VAULT, --vault URL Vault URL to open, skipping the selection menu
 
 -l LOGIN, --login LOGIN email for vault
+
+-k, --lock Locks vault
 
 -a AUTOTYPE, --autotype AUTOTYPE Override autotype sequence in config.ini
 


### PR DESCRIPTION
Adds `--lock` option to `bwm` command. `--lock` will lock the vault, as if the "lock vault" option had been selected from the menu. Useful for scripting, e.g. to lock the vault before computer sleeps.