### PR TITLE
Added -o flag to wl-copy to erase the clipboard after the first paste.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For full installation documention see the [installation docs][docs/install.md].
 - Supports multiple [bitwarden.com](https://bitwarden.com) and self-hosted
   [Vaultwarden][5] accounts. Accounts can be switched on the fly.
 - Auto-type username and/or password on selection. Select to clipboard if
-  desired (clipboard clears after 30 sec).
+  desired (clipboard clears after 30 sec on X11 or after 1 paste on Wayland).
 - Supports login with 2FA code from Authenticator(TOTP), Email, or Yubikey.
 - Background process allows selectable time-out for locking the database.
 - Use a custom [Keepass 2.x style auto-type sequence][6].

--- a/bwm/__init__.py
+++ b/bwm/__init__.py
@@ -21,7 +21,7 @@ SECRET_VALID_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 CLIPBOARD = False
 CLIPBOARD_CMD = "true"
 if os.environ.get('WAYLAND_DISPLAY'):
-    clips = ['wl-copy']
+    clips = ['wl-copy -o']
 else:
     clips = ["xsel -b", "xclip -selection clip"]
 for clip in clips:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,9 +40,10 @@
 - *Type entries*
     - Auto-type username and/or password on selection. Use xdotool, ydotool, or
       wtype for non-U.S. English keyboard layout.
-    - Select to clipboard if desired (clears clipboard after 30s). If `view/type
-      individual entries` isn't selected first, it will copy the password field
-      to the clipboard if it exists, otherwise will raise an error.
+    - Select to clipboard if desired (clears clipboard after 30s on X11 or after
+      one paste on Wayland). If `view/type individual entries` isn't selected
+      first, it will copy the password field to the clipboard if it exists,
+      otherwise will raise an error.
     - Use a custom [Keepass 2.x style auto-type sequence][1] if you have one
       defined
       (except for character repetition and the 'special commands'). Set it per entry


### PR DESCRIPTION
From wl-copy -h:
`-o, --paste-once        Only serve one paste request and then exit.`