### PR TITLE
Update menu.py to use the -mesg feature instead of -p

### DIFF
--- a/bwm/menu.py
+++ b/bwm/menu.py
@@ -19,7 +19,7 @@ def dmenu_cmd(num_lines, prompt):
     """
     commands = {"bemenu": ["-p", str(prompt), "-l", str(num_lines)],
                 "dmenu": ["-p", str(prompt), "-l", str(num_lines)],
-                "rofi": ["-dmenu", "-p", str(prompt), "-l", str(num_lines)],
+                "rofi": ["-dmenu", "-mesg", str(prompt), "-l", str(num_lines)],
                 "wofi": ["--dmenu", "-p", str(prompt), "-L", str(num_lines + 1)]}
     command = shlex.split(bwm.CONF.get('dmenu', 'dmenu_command', fallback='dmenu'))
     command.extend(commands.get(command[0], []))


### PR DESCRIPTION
Popular rofi themes often dont support the -p flag, but do support the mesg prompt.

Kindly consider the pros and cons of this change.